### PR TITLE
fix(register): return 409 instead 410 when user already exist

### DIFF
--- a/src/lib/factories/userFactory.ts
+++ b/src/lib/factories/userFactory.ts
@@ -20,7 +20,7 @@ class UserFactory implements IUserFactory {
             });
             if (user) {
                 return Promise.reject({
-                    statusCode: 410,
+                    statusCode: 409,
                     message: 'User already exist',
                 });
             }

--- a/src/tests/integration-tests/auth/auth.spec.ts
+++ b/src/tests/integration-tests/auth/auth.spec.ts
@@ -26,7 +26,7 @@ describe('when a user register', () => {
             .post('/users')
             .send(newUser)
             .set('Content-Type', 'application/json');
-        expect(res.status).toBe(410);
+        expect(res.status).toBe(409);
     });
 
     void it('should return 422 with bad email', async () => {

--- a/src/tests/unit-tests/auth/auth.test.ts
+++ b/src/tests/unit-tests/auth/auth.test.ts
@@ -15,7 +15,7 @@ describe('when a user register', () => {
 
     void it('should not be able to create another account with the same email', async () => {
         await expect(userFactory.create(newUser)).rejects.toEqual({
-            statusCode: 410,
+            statusCode: 409,
             message: 'User already exist',
         });
     });


### PR DESCRIPTION
ref: https://github.com/esport-hatcher/api-v1/issues/22