### PR TITLE
refacto(Events)

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:12
 WORKDIR /app
 COPY ./package.json ./
 RUN yarn install

--- a/src/db/SequelizeDb.ts
+++ b/src/db/SequelizeDb.ts
@@ -98,8 +98,7 @@ class SequelizeDb {
          * Events belong to team
          */
         Event.belongsTo(Team, {
-            constraints: true,
-            onDelete: 'cascade',
+            constraints: false,
         });
         Team.hasMany(Event);
 
@@ -107,7 +106,7 @@ class SequelizeDb {
          * An event can have many users
          * A user can have many events
          */
-        Event.belongsToMany(User, { through: EventUser });
+        Event.belongsToMany(User, { through: EventUser, onDelete: 'cascade' });
         User.belongsToMany(Event, { through: EventUser });
 
         /**

--- a/src/db/models/Event.ts
+++ b/src/db/models/Event.ts
@@ -21,6 +21,7 @@ export class Event extends Model {
     public place!: string;
     public dateBegin!: Date;
     public dateEnd!: Date;
+    public readonly TeamId: number;
     public readonly createdAt!: Date;
     public readonly updatedAt!: Date;
 

--- a/src/db/models/User.ts
+++ b/src/db/models/User.ts
@@ -3,6 +3,7 @@ import {
     DataTypes,
     Sequelize,
     BelongsToManyGetAssociationsMixin,
+    BelongsToManyAddAssociationMixin,
 } from 'sequelize';
 import { hash } from 'bcryptjs';
 import { encode } from 'jwt-simple';
@@ -51,6 +52,9 @@ export class User extends Model {
     public readonly updatedAt!: Date;
     public getTeams!: BelongsToManyGetAssociationsMixin<Team>;
     public getTasks!: BelongsToManyGetAssociationsMixin<Task>;
+    public getEvents!: BelongsToManyGetAssociationsMixin<Event>;
+
+    public addEvent!: BelongsToManyAddAssociationMixin<Event, EventUser>;
 
     public TeamUser: TeamUser;
     public TaskUser: TaskUser;

--- a/src/lib/controllers/ModelController.ts
+++ b/src/lib/controllers/ModelController.ts
@@ -14,10 +14,7 @@ export abstract class ModelController<
     private readonly modelName: string;
 
     constructor(private readonly model: T) {
-        this.modelName = this.model
-            .toString()
-            .split(' ')[1]
-            .toLowerCase();
+        this.modelName = this.model.toString().split(' ')[1].toLowerCase();
         this.findAll = this.findAll.bind(this);
         this.findById = this.findById.bind(this);
         this.deleteById = this.deleteById.bind(this);

--- a/src/lib/middlewares/index.ts
+++ b/src/lib/middlewares/index.ts
@@ -7,3 +7,4 @@ export * from './requireTeamOwnerOrAdmin';
 export * from './requireFiltersOrPagination';
 export * from './requireOwnerTeamMember';
 export * from './requireUserTeamMember';
+export * from './requirePersonalEvent';

--- a/src/lib/middlewares/requirePersonalEvent.ts
+++ b/src/lib/middlewares/requirePersonalEvent.ts
@@ -1,0 +1,20 @@
+import { Response, NextFunction } from 'express';
+import { IRequest } from '@typings';
+import { unauthorizedError } from '@utils';
+
+export const requirePersonalEvent = async (
+    req: IRequest,
+    _res: Response,
+    next: NextFunction
+) => {
+    const { event, owner } = req;
+
+    const eventBelongsToUser = await owner.getEvents({
+        where: { id: event.id },
+    });
+
+    if (!eventBelongsToUser || event.TeamId) {
+        return next(unauthorizedError('Event does not belong to this user'));
+    }
+    return next();
+};

--- a/src/lib/routes/userRoutes.ts
+++ b/src/lib/routes/userRoutes.ts
@@ -1,6 +1,6 @@
 import { body } from 'express-validator/check';
 import { BaseRouter } from '@services/router';
-import { userController } from '@controllers';
+import { userController, eventController } from '@controllers';
 import {
     requireValidation,
     requireScopeOrSuperAdmin,
@@ -85,6 +85,21 @@ userRoutes.delete(
     requireAuth,
     requireScopeOrSuperAdmin,
     userController.deleteById
+);
+
+/** EVENTS */
+userRoutes.post(
+    '/:userId/events',
+    requireAuth,
+    requireScopeOrSuperAdmin,
+    eventController.create
+);
+
+userRoutes.get(
+    '/:userId/events',
+    requireAuth,
+    requireScopeOrSuperAdmin,
+    eventController.findAllByUser
 );
 
 export { userRoutes };

--- a/src/lib/routes/userRoutes.ts
+++ b/src/lib/routes/userRoutes.ts
@@ -6,6 +6,7 @@ import {
     requireScopeOrSuperAdmin,
     requireAuth,
     requireFiltersOrPagination,
+    requirePersonalEvent,
 } from '@middlewares';
 
 const userRoutes = BaseRouter();
@@ -100,6 +101,30 @@ userRoutes.get(
     requireAuth,
     requireScopeOrSuperAdmin,
     eventController.findAllByUser
+);
+
+userRoutes.get(
+    '/:userId/events/:eventId',
+    requireAuth,
+    requireScopeOrSuperAdmin,
+    requirePersonalEvent,
+    eventController.findById
+);
+
+userRoutes.patch(
+    '/:userId/events/:eventId',
+    requireAuth,
+    requireScopeOrSuperAdmin,
+    requirePersonalEvent,
+    eventController.updateById
+);
+
+userRoutes.delete(
+    '/:userId/events/:eventId',
+    requireAuth,
+    requireScopeOrSuperAdmin,
+    requirePersonalEvent,
+    eventController.deleteById
 );
 
 export { userRoutes };

--- a/src/tests/integration-tests/events.spec.ts
+++ b/src/tests/integration-tests/events.spec.ts
@@ -7,10 +7,12 @@ import { User, Team, Event } from '@models';
 describe('A regular user', () => {
     let user: User;
     let secondUser: User;
+    let event: Event;
 
     beforeAll(async () => {
         user = await getUser();
         secondUser = await getUser();
+        event = await getEvent(user);
     });
 
     void it('can create a personal event and it returns 201', async () => {
@@ -25,6 +27,31 @@ describe('A regular user', () => {
     void it('can fetch all events and it returns 200', async () => {
         const res = await request(app)
             .get(`/users/${user.id}/events`)
+            .set('Content-Type', 'application/json')
+            .set('Authorization', `Bearer ${user.getAccessToken()}`);
+        expect(res.status).toBe(200);
+    });
+
+    void it('can fetch an event by his id and it returns 200', async () => {
+        const res = await request(app)
+            .get(`/users/${user.id}/events/${event.id}`)
+            .set('Content-Type', 'application/json')
+            .set('Authorization', `Bearer ${user.getAccessToken()}`);
+        expect(res.status).toBe(200);
+    });
+
+    void it('can update an event and it returns 200', async () => {
+        const res = await request(app)
+            .patch(`/users/${user.id}/events/${event.id}`)
+            .send(getRandomEventProps())
+            .set('Content-Type', 'application/json')
+            .set('Authorization', `Bearer ${user.getAccessToken()}`);
+        expect(res.status).toBe(200);
+    });
+
+    void it('can fetch all events and it returns 200', async () => {
+        const res = await request(app)
+            .delete(`/users/${user.id}/events/${event.id}`)
             .set('Content-Type', 'application/json')
             .set('Authorization', `Bearer ${user.getAccessToken()}`);
         expect(res.status).toBe(200);
@@ -57,7 +84,7 @@ describe('A team owner', () => {
         logger('Tests', 'Generating access token...');
         teamOwner = await getUser();
         team = await getTeam({ user: teamOwner });
-        event = await getEvent(team);
+        event = await getEvent(null, team);
     });
 
     void it('can create an event and it returns 201', async () => {
@@ -135,7 +162,7 @@ describe('A team owner', () => {
 
         beforeAll(async () => {
             otherTeamUser = await getUser();
-            event = await getEvent(team);
+            event = await getEvent(null, team);
             await team.addPlayer(otherTeamUser);
         });
 
@@ -259,7 +286,7 @@ describe('A team admin', () => {
         logger('Tests', 'Generating access token...');
         teamAdmin = await getUser();
         team = await getTeam({ user: teamAdmin, role: 'Admin' });
-        event = await getEvent(team);
+        event = await getEvent(null, team);
     });
 
     void it('can create an event and it returns 201', async () => {
@@ -337,7 +364,7 @@ describe('A team admin', () => {
 
         beforeAll(async () => {
             otherTeamUser = await getUser();
-            event = await getEvent(team);
+            event = await getEvent(null, team);
             await team.addPlayer(otherTeamUser);
         });
 
@@ -460,7 +487,7 @@ describe('A team player', () => {
         logger('Tests', 'Generating access token...');
         teamPlayer = await getUser();
         team = await getTeam({ user: teamPlayer, role: 'Player' });
-        event = await getEvent(team);
+        event = await getEvent(null, team);
     });
 
     void it('cannot create an event and it returns 401', async () => {
@@ -522,7 +549,7 @@ describe('A team player', () => {
 
         beforeAll(async () => {
             otherTeamUser = await getUser();
-            event = await getEvent(team);
+            event = await getEvent(null, team);
             await team.addPlayer(otherTeamUser);
             await event.addUser(otherTeamUser);
         });
@@ -586,7 +613,7 @@ describe('A random user who is not in the team', () => {
         logger('Tests', 'Generating access token...');
         randomUser = await getUser();
         team = await getTeam();
-        event = await getEvent(team);
+        event = await getEvent(null, team);
     });
 
     void it('cannot create an event and it returns 401', async () => {
@@ -638,7 +665,7 @@ describe('A random user who is not in the team', () => {
 
         beforeAll(async () => {
             otherTeamUser = await getUser();
-            event = await getEvent(team);
+            event = await getEvent(null, team);
             await team.addPlayer(otherTeamUser);
         });
 

--- a/src/tests/integration-tests/events.spec.ts
+++ b/src/tests/integration-tests/events.spec.ts
@@ -4,6 +4,50 @@ import { app } from '@app';
 import { logger, getRandomEventProps } from '@utils';
 import { User, Team, Event } from '@models';
 
+describe('A regular user', () => {
+    let user: User;
+    let secondUser: User;
+
+    beforeAll(async () => {
+        user = await getUser();
+        secondUser = await getUser();
+    });
+
+    void it('can create a personal event and it returns 201', async () => {
+        const res = await request(app)
+            .post(`/users/${user.id}/events`)
+            .send(getRandomEventProps())
+            .set('Content-Type', 'application/json')
+            .set('Authorization', `Bearer ${user.getAccessToken()}`);
+        expect(res.status).toBe(201);
+    });
+
+    void it('can fetch all events and it returns 200', async () => {
+        const res = await request(app)
+            .get(`/users/${user.id}/events`)
+            .set('Content-Type', 'application/json')
+            .set('Authorization', `Bearer ${user.getAccessToken()}`);
+        expect(res.status).toBe(200);
+    });
+
+    void it('cannot create personal events for another user and it returns 401', async () => {
+        const res = await request(app)
+            .post(`/users/${user.id}/events`)
+            .send(getRandomEventProps())
+            .set('Content-Type', 'application/json')
+            .set('Authorization', `Bearer ${secondUser.getAccessToken()}`);
+        expect(res.status).toBe(401);
+    });
+
+    void it('cannot fetch the events of another user and it returns 401', async () => {
+        const res = await request(app)
+            .get(`/users/${user.id}/events`)
+            .set('Content-Type', 'application/json')
+            .set('Authorization', `Bearer ${secondUser.getAccessToken()}`);
+        expect(res.status).toBe(401);
+    });
+});
+
 describe('A team owner', () => {
     let teamOwner: User;
     let team: Team;
@@ -78,7 +122,7 @@ describe('A team owner', () => {
         expect(res.status).toBe(404);
     });
 
-    void it('cannot delete an eevent who does not exist and it returns 404', async () => {
+    void it('cannot delete an event who does not exist and it returns 404', async () => {
         const res = await request(app)
             .delete(`/teams/${team.id}/events/42`)
             .set('Content-Type', 'application/json')
@@ -280,7 +324,7 @@ describe('A team admin', () => {
         expect(res.status).toBe(404);
     });
 
-    void it('cannot delete an eevent who does not exist and it returns 404', async () => {
+    void it('cannot delete an event who does not exist and it returns 404', async () => {
         const res = await request(app)
             .delete(`/teams/${team.id}/events/42`)
             .set('Content-Type', 'application/json')

--- a/src/tests/integration-tests/users.spec.ts
+++ b/src/tests/integration-tests/users.spec.ts
@@ -13,7 +13,7 @@ describe('when logged in as a normal user', () => {
         secondUser = await getUser();
     });
 
-    void it('can fetch all users', async () => {
+    void it('can fetch all users and it returns 200', async () => {
         const res = await request(app)
             .get('/users')
             .set('Content-Type', 'application/json')
@@ -21,19 +21,11 @@ describe('when logged in as a normal user', () => {
         expect(res.status).toBe(200);
     });
 
-    void it('change his records', async () => {
+    void it('change his records and it returns 200', async () => {
         const patchedUser = { username: 'Yun Yun' };
         const res = await request(app)
             .patch(`/users/${user.id}`)
             .send(patchedUser)
-            .set('Content-Type', 'application/json')
-            .set('Authorization', `Bearer ${user.getAccessToken()}`);
-        expect(res.status).toBe(200);
-    });
-
-    void it('delete his account', async () => {
-        const res = await request(app)
-            .delete(`/users/${user.id}`)
             .set('Content-Type', 'application/json')
             .set('Authorization', `Bearer ${user.getAccessToken()}`);
         expect(res.status).toBe(200);
@@ -55,6 +47,14 @@ describe('when logged in as a normal user', () => {
             .set('Content-Type', 'application/json')
             .set('Authorization', `Bearer ${user.getAccessToken()}`);
         expect(res.status).toBe(401);
+    });
+
+    void it('should return 200 when deleting his account', async () => {
+        const res = await request(app)
+            .delete(`/users/${user.id}`)
+            .set('Content-Type', 'application/json')
+            .set('Authorization', `Bearer ${user.getAccessToken()}`);
+        expect(res.status).toBe(200);
     });
 });
 

--- a/src/tests/utils/modelGenerator.ts
+++ b/src/tests/utils/modelGenerator.ts
@@ -44,18 +44,22 @@ export const getTeam = async (
 };
 
 /**
- *
+ * @param user - User from which the event will be created
  * @param team - Team from which the event will be created
  * @param eventProps  - optional
  */
 export const getEvent = async (
-    team: Team,
-    eventProps?: IEventProps
+    user: User | null = null,
+    team: Team | null = null,
+    eventProps: IEventProps = getRandomEventProps()
 ): Promise<Event> => {
-    return team.createEvent(
+    if (team) {
         // tslint:disable-next-line: no-any
-        (eventProps ? eventProps : getRandomEventProps()) as any
-    );
+        return team.createEvent(eventProps as any);
+    }
+    const event = await Event.create(eventProps);
+    await user.addEvent(event);
+    return event;
 };
 
 /**


### PR DESCRIPTION
- made relation with `Team` optional
- added route `POST /users/:userId/events`
- added route `GET /users/:userId/events`
- added related tests
- updated `NODE_ENV` in `client_container`  from `node-alpine:11.10.5` to `node:12`
- added rest of the methods for `events` on `userRoutes`
- added tests for `PATCH`, `GET (id)` and `DELETE` methods
- added custom middleware `requirePersonalEvent` to check that the `:eventId` belongs to the `owner` of the request and is indeed not linked to any `team`