### PR TITLE
refacto(Tasks)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
       "prettier --config .prettierrc.json --write",
-      "tslint -t stylish --project tsconfig.json --config tslint.json",
-      "git add"
+      "tslint -t stylish --project tsconfig.json --config tslint.json"
     ]
   },
   "dependencies": {

--- a/src/db/SequelizeDb.ts
+++ b/src/db/SequelizeDb.ts
@@ -114,8 +114,7 @@ class SequelizeDb {
          * A task belongs to a team
          */
         Task.belongsTo(Team, {
-            constraints: true,
-            onDelete: 'cascade',
+            constraints: false,
         });
         Team.hasMany(Task);
 
@@ -123,7 +122,7 @@ class SequelizeDb {
          * A task can have many users
          * A user can have many tasks
          */
-        Task.belongsToMany(User, { through: TaskUser });
+        Task.belongsToMany(User, { through: TaskUser, onDelete: 'cascade' });
         User.belongsToMany(Task, { through: TaskUser });
     }
 

--- a/src/db/models/Task.ts
+++ b/src/db/models/Task.ts
@@ -22,6 +22,7 @@ export class Task extends Model {
     public dateBegin: Date;
     public dateEnd!: Date;
     public completed: boolean;
+    public readonly TeamId: number;
     public readonly createdAt!: Date;
     public readonly updatedAt!: Date;
 

--- a/src/db/models/User.ts
+++ b/src/db/models/User.ts
@@ -9,7 +9,7 @@ import { hash } from 'bcryptjs';
 import { encode } from 'jwt-simple';
 import { createHashtag } from '@utils';
 import { jwtSecret } from '@config';
-import { Team, TeamUser, Task, TaskUser, EventUser } from '@models';
+import { Team, TeamUser, Event, EventUser, Task, TaskUser } from '@models';
 
 // import {
 // 	HasManyGetAssociationsMixin,
@@ -51,10 +51,11 @@ export class User extends Model {
     public readonly createdAt!: Date;
     public readonly updatedAt!: Date;
     public getTeams!: BelongsToManyGetAssociationsMixin<Team>;
-    public getTasks!: BelongsToManyGetAssociationsMixin<Task>;
     public getEvents!: BelongsToManyGetAssociationsMixin<Event>;
+    public getTasks!: BelongsToManyGetAssociationsMixin<Task>;
 
     public addEvent!: BelongsToManyAddAssociationMixin<Event, EventUser>;
+    public addTask!: BelongsToManyAddAssociationMixin<Task, TaskUser>;
 
     public TeamUser: TeamUser;
     public TaskUser: TaskUser;

--- a/src/lib/controllers/TeamsController.ts
+++ b/src/lib/controllers/TeamsController.ts
@@ -39,6 +39,22 @@ class TeamsController extends ModelController<typeof Team> {
     }
 
     @logRequest
+    async findAllByUser(
+        req: IRequest,
+        res: Response,
+        next: NextFunction
+    ): Promise<void | Response> {
+        const { user } = req;
+
+        try {
+            const teams = await user.getTeams();
+            return res.status(200).json(teams);
+        } catch (err) {
+            return next(err);
+        }
+    }
+
+    @logRequest
     async updateById(
         req: IRequest,
         res: Response,

--- a/src/lib/controllers/UserController.ts
+++ b/src/lib/controllers/UserController.ts
@@ -159,36 +159,6 @@ class UserController extends ModelController<typeof User> {
             return next(err);
         }
     }
-
-    @logRequest
-    async getUserTeam(
-        req: IRequest,
-        res: Response,
-        next: NextFunction
-    ): Promise<void | Response> {
-        try {
-            const { user } = req;
-            const userTeams = await user.getTeams();
-            return res.status(200).json(userTeams);
-        } catch (err) {
-            return next(err);
-        }
-    }
-
-    @logRequest
-    async getUserTask(
-        req: IRequest,
-        res: Response,
-        next: NextFunction
-    ): Promise<void | Response> {
-        try {
-            const { user } = req;
-            const userTasks = await user.getTasks();
-            return res.status(200).json(userTasks);
-        } catch (err) {
-            return next(err);
-        }
-    }
 }
 
 export const userController = new UserController();

--- a/src/lib/middlewares/index.ts
+++ b/src/lib/middlewares/index.ts
@@ -8,3 +8,4 @@ export * from './requireFiltersOrPagination';
 export * from './requireOwnerTeamMember';
 export * from './requireUserTeamMember';
 export * from './requirePersonalEvent';
+export * from './requirePersonalTask';

--- a/src/lib/middlewares/requirePersonalTask.ts
+++ b/src/lib/middlewares/requirePersonalTask.ts
@@ -1,0 +1,20 @@
+import { Response, NextFunction } from 'express';
+import { IRequest } from '@typings';
+import { unauthorizedError } from '@utils';
+
+export const requirePersonalTask = async (
+    req: IRequest,
+    _res: Response,
+    next: NextFunction
+) => {
+    const { task, owner } = req;
+
+    const taskBelongsToUser = await owner.getTasks({
+        where: { id: task.id },
+    });
+
+    if (!taskBelongsToUser || task.TeamId) {
+        return next(unauthorizedError('Task does not belong to this user'));
+    }
+    return next();
+};

--- a/src/lib/routes/userRoutes.ts
+++ b/src/lib/routes/userRoutes.ts
@@ -1,6 +1,11 @@
 import { body } from 'express-validator/check';
 import { BaseRouter } from '@services/router';
-import { userController, eventController, taskController } from '@controllers';
+import {
+    userController,
+    teamController,
+    eventController,
+    taskController,
+} from '@controllers';
 import {
     requireValidation,
     requireScopeOrSuperAdmin,
@@ -23,9 +28,12 @@ userRoutes.get(
 );
 
 userRoutes.get('/me', requireAuth, userController.getMe);
-
-userRoutes.get('/:userId/teams', requireAuth, userController.getUserTeam);
-userRoutes.get('/:userId/tasks', requireAuth, userController.getUserTask);
+userRoutes.get(
+    '/:userId/teams',
+    requireAuth,
+    requireScopeOrSuperAdmin,
+    teamController.findAllByUser
+);
 userRoutes.get('/:userId', requireAuth, userController.findById);
 
 /**

--- a/src/lib/routes/userRoutes.ts
+++ b/src/lib/routes/userRoutes.ts
@@ -1,12 +1,13 @@
 import { body } from 'express-validator/check';
 import { BaseRouter } from '@services/router';
-import { userController, eventController } from '@controllers';
+import { userController, eventController, taskController } from '@controllers';
 import {
     requireValidation,
     requireScopeOrSuperAdmin,
     requireAuth,
     requireFiltersOrPagination,
     requirePersonalEvent,
+    requirePersonalTask,
 } from '@middlewares';
 
 const userRoutes = BaseRouter();
@@ -125,6 +126,45 @@ userRoutes.delete(
     requireScopeOrSuperAdmin,
     requirePersonalEvent,
     eventController.deleteById
+);
+
+/** TASKS */
+userRoutes.post(
+    '/:userId/tasks',
+    requireAuth,
+    requireScopeOrSuperAdmin,
+    taskController.create
+);
+
+userRoutes.get(
+    '/:userId/tasks',
+    requireAuth,
+    requireScopeOrSuperAdmin,
+    taskController.findAllByUser
+);
+
+userRoutes.get(
+    '/:userId/tasks/:taskId',
+    requireAuth,
+    requireScopeOrSuperAdmin,
+    requirePersonalTask,
+    taskController.findById
+);
+
+userRoutes.patch(
+    '/:userId/tasks/:taskId',
+    requireAuth,
+    requireScopeOrSuperAdmin,
+    requirePersonalTask,
+    taskController.updateById
+);
+
+userRoutes.delete(
+    '/:userId/tasks/:taskId',
+    requireAuth,
+    requireScopeOrSuperAdmin,
+    requirePersonalTask,
+    taskController.deleteById
 );
 
 export { userRoutes };

--- a/src/tests/utils/modelGenerator.ts
+++ b/src/tests/utils/modelGenerator.ts
@@ -63,18 +63,22 @@ export const getEvent = async (
 };
 
 /**
- *
+ * @param user - User from which the task will be created
  * @param team - Team from which the task will be created
  * @param taskProps  - optional
  */
 export const getTask = async (
-    team: Team,
-    taskProps?: ITaskProps
+    user: User | null = null,
+    team: Team | null = null,
+    taskProps: ITaskProps = getRandomTaskProps()
 ): Promise<Task> => {
-    return team.createTask(
+    if (team) {
         // tslint:disable-next-line: no-any
-        (taskProps ? taskProps : getRandomTaskProps()) as any
-    );
+        return team.createTask(taskProps as any);
+    }
+    const task = await Task.create(taskProps);
+    await user.addTask(task);
+    return task;
 };
 
 /**


### PR DESCRIPTION
- made relation with `Team` optional
- added route `POST /users/:userId/tasks`
- added route `GET /users/:userId/tasks`
- added related tests
- added rest of the methods for `tasks` on `userRoutes`
- added tests for `PATCH`, `GET (id)` and `DELETE` methods
- added custom middleware `requirePersonalTask` to check that the `:taskId` belongs to the `owner` of the request and is indeed not linked to any `team`