### PR TITLE
feat(TeamUser)

### DIFF
--- a/src/db/models/TeamUser.ts
+++ b/src/db/models/TeamUser.ts
@@ -1,4 +1,5 @@
 import { Model, DataTypes, Sequelize, ENUM } from 'sequelize';
+import { getRandomLightColor } from '@utils';
 
 export type TeamUserRole = 'Admin' | 'Staff' | 'Player' | 'Owner';
 
@@ -7,6 +8,7 @@ export class TeamUser extends Model {
     public playerStatus!: boolean;
     public teamStatus!: boolean;
     public role!: TeamUserRole;
+    public color!: string;
     public readonly createdAt!: Date;
     public readonly updatedAt!: Date;
 }
@@ -33,6 +35,11 @@ export const initTeamUser = (db: Sequelize) => {
                 type: ENUM('Admin', 'Staff', 'Player', 'Owner'),
                 allowNull: false,
                 defaultValue: 'Player',
+            },
+            color: {
+                type: DataTypes.STRING,
+                allowNull: false,
+                defaultValue: getRandomLightColor(),
             },
         },
         {

--- a/src/lib/controllers/TeamsController.ts
+++ b/src/lib/controllers/TeamsController.ts
@@ -116,6 +116,31 @@ class TeamsController extends ModelController<typeof Team> {
             return next(err);
         }
     }
+
+    @logRequest
+    async patchTeamUser(
+        req: IRequest,
+        res: Response,
+        next: NextFunction
+    ): Promise<void | Response> {
+        try {
+            const { owner, user } = req;
+
+            if (
+                owner.TeamUser.role === 'Owner' ||
+                owner.TeamUser.role === 'Admin'
+            ) {
+                user.TeamUser.role = req.body.role || user.TeamUser.role;
+            }
+            if (owner.id === user.id) {
+                user.TeamUser.color = req.body.color || user.TeamUser.color;
+            }
+            await user.TeamUser.save();
+            return res.status(200).json(user.get({ plain: true }));
+        } catch (err) {
+            return next(err);
+        }
+    }
 }
 
 export const teamController = new TeamsController();

--- a/src/lib/middlewares/index.ts
+++ b/src/lib/middlewares/index.ts
@@ -8,3 +8,4 @@ export * from './requireFiltersOrPagination';
 export * from './requireOwnerTeamMember';
 export * from './requireUserTeamMember';
 export * from './requirePersonalEvent';
+export * from './requireOwnerUserOrTeamAdmin';

--- a/src/lib/middlewares/requireOwnerUserOrTeamAdmin.ts
+++ b/src/lib/middlewares/requireOwnerUserOrTeamAdmin.ts
@@ -2,25 +2,27 @@ import { Response, NextFunction } from 'express';
 import { IRequest } from '@typings';
 import { unauthorizedError } from '@utils';
 
-export const requireOwnerTeamMember = async (
+export const requireOwnerUserOrTeamAdmin = async (
     req: IRequest,
     _res: Response,
     next: NextFunction
 ) => {
-    const { owner, team } = req;
+    const { owner, team, user } = req;
 
     try {
         const teamUsers = await team.getUsers();
         const ownerInTeam = teamUsers.find(user => user.id === owner.id);
+        const userInTeam = teamUsers.find(_user => _user.id === user.id);
 
         if (
-            !ownerInTeam ||
+            (user.id !== owner.id && ownerInTeam.TeamUser.role !== 'Admin') ||
             !ownerInTeam.TeamUser.playerStatus ||
             !ownerInTeam.TeamUser.teamStatus
         ) {
             return next(unauthorizedError('User not part of the team'));
         }
-        /** gives access to TeamUser in req.owner */
+        /** gives access to TeamUser in req.user and req.owner */
+        req.user = userInTeam;
         req.owner = ownerInTeam;
         return next();
     } catch (err) {

--- a/src/lib/routes/teamsRoutes.ts
+++ b/src/lib/routes/teamsRoutes.ts
@@ -7,6 +7,8 @@ import {
     requireValidation,
     requireTeamOwnerOrAdmin,
     requireFiltersOrPagination,
+    requireOwnerUserOrTeamAdmin,
+    requireOwnerTeamMember,
 } from '@middlewares';
 import { teamController } from '@controllers';
 
@@ -53,7 +55,12 @@ teamsRoutes.delete(
  * Routes related to team members
  */
 
-teamsRoutes.get('/:teamId/users', requireAuth, teamController.getTeamUser);
+teamsRoutes.get(
+    '/:teamId/users',
+    requireAuth,
+    requireOwnerTeamMember,
+    teamController.getTeamUser
+);
 
 teamsRoutes.post(
     '/:teamId/users/:userId',
@@ -62,4 +69,9 @@ teamsRoutes.post(
     teamController.addTeamUser
 );
 
+teamsRoutes.patch(
+    '/:teamId/users/:userId',
+    requireOwnerUserOrTeamAdmin,
+    teamController.patchTeamUser
+);
 export { teamsRoutes };

--- a/src/lib/utils/getRandomColor.ts
+++ b/src/lib/utils/getRandomColor.ts
@@ -1,0 +1,2 @@
+export const getRandomLightColor = () =>
+    'hsl(' + Math.random() * 360 + ', 100%, 75%)';

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -6,3 +6,4 @@ export * from './logger';
 export * from './validators';
 export * from './modelPropsGenerator';
 export * from './uploader';
+export * from './getRandomColor';


### PR DESCRIPTION
- added `color` field to `TeamUser` for UI purposes and to easily filter between `Teams`
- added `requireOwnerUserOrTeamAdmin` middleware to check that the `user` making the request is either targeting his instance in the team or have the correct access rights to target someone else instance
- added `patchTeamUser` method to `TeamController` to be able to modify `role` and `color` of a `TeamUser` 